### PR TITLE
upgraded estafette-ci-manifest to 0.0.19 to support global envvars

### DIFF
--- a/govendor.sh
+++ b/govendor.sh
@@ -8,7 +8,7 @@ govendor fetch github.com/dgrijalva/jwt-go@v3.0.0
 govendor fetch github.com/stretchr/testify/assert@v1.1.4
 govendor fetch github.com/stretchr/testify/mock@v1.1.4
 govendor fetch github.com/sethgrid/pester
-govendor fetch github.com/estafette/estafette-ci-manifest@0.0.17
+govendor fetch github.com/estafette/estafette-ci-manifest@0.0.19
 govendor fetch github.com/gin-gonic/gin@v1.2
 govendor fetch github.com/gin-contrib/gzip
 govendor fetch github.com/estafette/estafette-ci-crypt@0.0.1

--- a/vendor/github.com/estafette/estafette-ci-manifest/builder.go
+++ b/vendor/github.com/estafette/estafette-ci-manifest/builder.go
@@ -1,0 +1,6 @@
+package manifest
+
+// EstafetteBuilder contains configuration for the ci-builder component
+type EstafetteBuilder struct {
+	Track string `yaml:"track,omitempty"`
+}

--- a/vendor/github.com/estafette/estafette-ci-manifest/pipeline.go
+++ b/vendor/github.com/estafette/estafette-ci-manifest/pipeline.go
@@ -1,0 +1,13 @@
+package manifest
+
+// EstafettePipeline is the object that parts of the .estafette.yaml deserialize to
+type EstafettePipeline struct {
+	Name             string
+	ContainerImage   string            `yaml:"image,omitempty"`
+	Shell            string            `yaml:"shell,omitempty"`
+	WorkingDirectory string            `yaml:"workDir,omitempty"`
+	Commands         []string          `yaml:"commands,omitempty"`
+	When             string            `yaml:"when,omitempty"`
+	EnvVars          map[string]string `yaml:"env,omitempty"`
+	CustomProperties map[string]interface{}
+}

--- a/vendor/github.com/estafette/estafette-ci-manifest/test-manifest.yaml
+++ b/vendor/github.com/estafette/estafette-ci-manifest/test-manifest.yaml
@@ -14,6 +14,10 @@ version:
     labelTemplate: '{{branch}}'
     releaseBranch: master
 
+env:
+  VAR_A: Greetings
+  VAR_B: World
+
 pipelines:
   build:
     image: golang:1.8.0-alpine

--- a/vendor/github.com/estafette/estafette-ci-manifest/version.go
+++ b/vendor/github.com/estafette/estafette-ci-manifest/version.go
@@ -1,0 +1,88 @@
+package manifest
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+)
+
+// EstafetteVersion is the object that determines how version numbers are generated
+type EstafetteVersion struct {
+	SemVer *EstafetteSemverVersion `yaml:"semver,omitempty"`
+	Custom *EstafetteCustomVersion `yaml:"custom,omitempty"`
+}
+
+// Version returns the version number as a string
+func (v *EstafetteVersion) Version(params EstafetteVersionParams) string {
+	if v.Custom != nil {
+		return v.Custom.Version(params)
+	}
+	if v.SemVer != nil {
+		return v.SemVer.Version(params)
+	}
+	return ""
+}
+
+// EstafetteCustomVersion represents a custom version using a template
+type EstafetteCustomVersion struct {
+	LabelTemplate string `yaml:"labelTemplate,omitempty"`
+}
+
+// Version returns the version number as a string
+func (v *EstafetteCustomVersion) Version(params EstafetteVersionParams) string {
+	return parseTemplate(v.LabelTemplate, params.GetFuncMap())
+}
+
+// EstafetteSemverVersion represents semantic versioning (http://semver.org/)
+type EstafetteSemverVersion struct {
+	Major         int    `yaml:"major,omitempty"`
+	Minor         int    `yaml:"minor,omitempty"`
+	Patch         string `yaml:"patch,omitempty"`
+	LabelTemplate string `yaml:"labelTemplate,omitempty"`
+	ReleaseBranch string `yaml:"releaseBranch,omitempty"`
+}
+
+// Version returns the version number as a string
+func (v *EstafetteSemverVersion) Version(params EstafetteVersionParams) string {
+
+	patch := parseTemplate(v.Patch, params.GetFuncMap())
+
+	label := ""
+	if params.Branch != v.ReleaseBranch {
+		label = fmt.Sprintf("-%v", parseTemplate(v.LabelTemplate, params.GetFuncMap()))
+	}
+
+	return fmt.Sprintf("%v.%v.%v%v", v.Major, v.Minor, patch, label)
+}
+
+// EstafetteVersionParams contains parameters used to generate a version number
+type EstafetteVersionParams struct {
+	AutoIncrement int
+	Branch        string
+	Revision      string
+}
+
+// GetFuncMap returns EstafetteVersionParams as a function map for use in templating
+func (p *EstafetteVersionParams) GetFuncMap() template.FuncMap {
+
+	return template.FuncMap{
+		"auto":     func() string { return fmt.Sprint(p.AutoIncrement) },
+		"branch":   func() string { return p.Branch },
+		"revision": func() string { return p.Revision },
+	}
+}
+
+func parseTemplate(templateText string, funcMap template.FuncMap) string {
+	tmpl, err := template.New("version").Funcs(funcMap).Parse(templateText)
+	if err != nil {
+		return err.Error()
+	}
+
+	buf := new(bytes.Buffer)
+	err = tmpl.Execute(buf, nil)
+	if err != nil {
+		return err.Error()
+	}
+
+	return buf.String()
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -309,12 +309,12 @@
 			"versionExact": "0.0.1"
 		},
 		{
-			"checksumSHA1": "9wIMYT4rC1gDzXi7QigrDBuEKF4=",
+			"checksumSHA1": "O+UeFi9kekgTc854ud3+a+R/NoA=",
 			"path": "github.com/estafette/estafette-ci-manifest",
-			"revision": "1116e789715434785c1136a776dd0127736ba016",
-			"revisionTime": "2017-09-13T07:40:17Z",
-			"version": "0.0.17",
-			"versionExact": "0.0.17"
+			"revision": "a385e216281355fa415fceadc633d12070f5fa57",
+			"revisionTime": "2017-11-09T14:46:31Z",
+			"version": "0.0.19",
+			"versionExact": "0.0.19"
 		},
 		{
 			"checksumSHA1": "TDysVqhcacAS+H/fqk5X2egtcrA=",


### PR DESCRIPTION
Doesn't really add anything to the api, but it at least keeps it up to date.