### PR TITLE
specify actions for release target to use canary releases

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -52,6 +52,10 @@ stages:
 
 releases:
   tooling:
+    actions:
+    - name: deploy-canary
+    - name: deploy-stable
+    - name: rollback-canary
     clone: true
     stages:
       deploy:


### PR DESCRIPTION
Switching to canary releases for limited impact in case of erroneous code or config changes.