### PR TITLE
Store logs in gcs

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -145,6 +145,8 @@ releases:
             BIGQUERY_ENABLED: true
             BIGQUERY_PROJECT: estafette.secret(1lPI_NGTMRnDDDhA.mrk90yihnaF5m3BiBTTAQ58kmcnGvb9fAQy6EVW7BeQ_GN-NIF8=)
             BIGQUERY_DATASET: estafette.secret(nGD0saRGkh7gFwgj.s5OEH5W_SGuO2vK4ELUDMNKC2ocsr8ZGnlkvfg==)
+            GCS_PROJECT: estafette.secret(LIjgWfp08nYecZp7.cOHELtluCzWPEadxlPYunj8wtN05faVoeIzRj5v6new9qa9WSNo=)
+            GCS_BUCKET: estafette.secret(64NRos_WoXPpM-k3.ZISQfPOjRkVeyPf3pjxFCzfjt_DyAUn-S8IQBQ==)
             ESTAFETTE_CI_API_KEY: estafette.secret(IhMzR1XM4wCysGPN.cGRQKuqylJjPnWPKQHS3Sbso3bBUshtJDpOjDU39bbJrkC0nuXdLzBy51eYlrB02SfYQeg8_muLZd3Fb1AcLy1zXKeJZ-83-McjbI9_BHC_fabixDTnfbPgQvtGymiSW3Jyt_3-Elo7_X93jeXklQ56XkQ==)
             IAP_AUDIENCE: estafette.secret(8PWwRhfBLO0N4eai.LLC-WvS8oz_z-J16dqJZnIMeA7nH50KgoMlCnbYDxZPRGVY8TjfdMNhhcwx5vWciJDTQLk9_9m9RajsmSDsqckI8O-deCTDTQabFEkmDiW9SnQ==)
             CONTAINER_REPOSITORY_1: estafette.secret(IttHCpEKQGXIaQBE.x7dPyVFhQeuL6JUUp4lJOLTKjwnc6A==)

--- a/config/config.go
+++ b/config/config.go
@@ -66,12 +66,13 @@ type DatabaseConfig struct {
 
 // APIConfigIntegrations contains config for 3rd party integrations
 type APIConfigIntegrations struct {
-	Github     *GithubConfig     `yaml:"github,omitempty"`
-	Bitbucket  *BitbucketConfig  `yaml:"bitbucket,omitempty"`
-	Slack      *SlackConfig      `yaml:"slack,omitempty"`
-	Pubsub     *PubsubConfig     `yaml:"pubsub,omitempty"`
-	Prometheus *PrometheusConfig `yaml:"prometheus,omitempty"`
-	BigQuery   *BigQueryConfig   `yaml:"bigquery,omitempty"`
+	Github       *GithubConfig       `yaml:"github,omitempty"`
+	Bitbucket    *BitbucketConfig    `yaml:"bitbucket,omitempty"`
+	Slack        *SlackConfig        `yaml:"slack,omitempty"`
+	Pubsub       *PubsubConfig       `yaml:"pubsub,omitempty"`
+	Prometheus   *PrometheusConfig   `yaml:"prometheus,omitempty"`
+	BigQuery     *BigQueryConfig     `yaml:"bigquery,omitempty"`
+	CloudStorage *CloudStorageConfig `yaml:"gcs,omitempty"`
 }
 
 // GithubConfig is used to configure github integration
@@ -108,6 +109,13 @@ type PubsubConfig struct {
 	ServiceAccountEmail            string `yaml:"serviceAccountEmail"`
 	SubscriptionNameSuffix         string `yaml:"subscriptionNameSuffix"`
 	SubscriptionIdleExpirationDays int    `yaml:"subscriptionIdleExpirationDays"`
+}
+
+// CloudStorageConfig is used to configure a google cloud storage bucket to be used to store logs
+type CloudStorageConfig struct {
+	ProjectID     string `yaml:"projectID"`
+	Bucket        string `yaml:"bucket"`
+	LogsDirectory string `yaml:"logsDir"`
 }
 
 // PrometheusConfig configures where to find prometheus for retrieving max cpu and memory consumption of build and release jobs

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"io/ioutil"
 
+	"github.com/estafette/estafette-ci-api/helpers"
 	contracts "github.com/estafette/estafette-ci-contracts"
 	crypt "github.com/estafette/estafette-ci-crypt"
 	"github.com/rs/zerolog/log"
@@ -26,8 +27,30 @@ type APIConfig struct {
 
 // APIServerConfig represents configuration for the api server
 type APIServerConfig struct {
-	BaseURL    string `yaml:"baseURL"`
-	ServiceURL string `yaml:"serviceURL"`
+	BaseURL    string   `yaml:"baseURL"`
+	ServiceURL string   `yaml:"serviceURL"`
+	LogWriters []string `yaml:"logWriters"`
+	LogReader  string   `yaml:"logReader"`
+}
+
+// WriteLogToDatabase indicates if database is in the logWriters config
+func (c *APIServerConfig) WriteLogToDatabase() bool {
+	return len(c.LogWriters) == 0 || helpers.StringArrayContains(c.LogWriters, "database")
+}
+
+// WriteLogToCloudStorage indicates if cloudstorage is in the logWriters config
+func (c *APIServerConfig) WriteLogToCloudStorage() bool {
+	return helpers.StringArrayContains(c.LogWriters, "cloudstorage")
+}
+
+// ReadLogFromDatabase indicates if logReader config is database
+func (c *APIServerConfig) ReadLogFromDatabase() bool {
+	return c.LogReader == "" || c.LogReader == "database"
+}
+
+// ReadLogFromCloudStorage indicates if logReader config is cloudstorage
+func (c *APIServerConfig) ReadLogFromCloudStorage() bool {
+	return c.LogReader == "cloudstorage"
 }
 
 // AuthConfig determines whether to use IAP for authentication and authorization

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -97,6 +97,20 @@ func TestReadConfigFromFile(t *testing.T) {
 		assert.Equal(t, "my-dataset", bigqueryConfig.Dataset)
 	})
 
+	t.Run("ReturnsCloudStorageConfig", func(t *testing.T) {
+
+		configReader := NewConfigReader(crypt.NewSecretHelper("SazbwMf3NZxVVbBqQHebPcXCqrVn3DDp", false))
+
+		// act
+		config, _ := configReader.ReadConfigFromFile("test-config.yaml", true)
+
+		cloudStorageConfig := config.Integrations.CloudStorage
+
+		assert.Equal(t, "my-gcp-project", cloudStorageConfig.ProjectID)
+		assert.Equal(t, "my-bucket", cloudStorageConfig.Bucket)
+		assert.Equal(t, "/logs", cloudStorageConfig.LogsDirectory)
+	})
+
 	t.Run("ReturnsAPIServerConfig", func(t *testing.T) {
 
 		configReader := NewConfigReader(crypt.NewSecretHelper("SazbwMf3NZxVVbBqQHebPcXCqrVn3DDp", false))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -122,6 +122,10 @@ func TestReadConfigFromFile(t *testing.T) {
 
 		assert.Equal(t, "https://ci.estafette.io/", apiServerConfig.BaseURL)
 		assert.Equal(t, "http://estafette-ci-api.estafette.svc.cluster.local/", apiServerConfig.ServiceURL)
+		assert.Equal(t, 2, len(apiServerConfig.LogWriters))
+		assert.Equal(t, "database", apiServerConfig.LogWriters[0])
+		assert.Equal(t, "cloudstorage", apiServerConfig.LogWriters[1])
+		assert.Equal(t, "database", apiServerConfig.LogReader)
 	})
 
 	t.Run("ReturnsAuthConfig", func(t *testing.T) {
@@ -284,3 +288,179 @@ func TestReadConfigFromFile(t *testing.T) {
 		assert.Equal(t, "{\"name\":\"gke-estafette-production\",\"type\":\"kubernetes-engine\",\"additionalProperties\":{\"cluster\":\"production-europe-west2\",\"defaults\":{\"autoscale\":{\"min\":2},\"container\":{\"repository\":\"estafette\"},\"namespace\":\"estafette\",\"sidecars\":[{\"image\":\"estafette/openresty-sidecar:1.13.6.1-alpine\",\"type\":\"openresty\"}]},\"project\":\"estafette-production\",\"region\":\"europe-west2\",\"serviceAccountKeyfile\":\"{}\"}}", string(bytes))
 	})
 }
+
+func TestWriteLogToDatabase(t *testing.T) {
+
+	t.Run("ReturnsTrueIfLogWritersIsEmpty", func(t *testing.T) {
+
+		config := APIServerConfig{
+			LogWriters: []string{},
+		}
+
+		// act
+		result := config.WriteLogToDatabase()
+
+		assert.True(t, result)
+	})
+
+	t.Run("ReturnsTrueIfLogWritersContainsDatabase", func(t *testing.T) {
+
+		config := APIServerConfig{
+			LogWriters: []string{
+				"cloudstorage",
+				"database",
+			},
+		}
+
+		// act
+		result := config.WriteLogToDatabase()
+
+		assert.True(t, result)
+	})
+
+	t.Run("ReturnsFalseIfLogWritersDoesNotContainDatabase", func(t *testing.T) {
+
+		config := APIServerConfig{
+			LogWriters: []string{
+				"cloudstorage",
+			},
+		}
+
+		// act
+		result := config.WriteLogToDatabase()
+
+		assert.False(t, result)
+	})
+}
+
+func TestWriteLogToCloudStorage(t *testing.T) {
+
+	t.Run("ReturnsFalseIfLogWritersIsEmpty", func(t *testing.T) {
+
+		config := APIServerConfig{
+			LogWriters: []string{},
+		}
+
+		// act
+		result := config.WriteLogToCloudStorage()
+
+		assert.False(t, result)
+	})
+
+	t.Run("ReturnsTrueIfLogWritersContainsCloudStorage", func(t *testing.T) {
+
+		config := APIServerConfig{
+			LogWriters: []string{
+				"cloudstorage",
+				"database",
+			},
+		}
+
+		// act
+		result := config.WriteLogToCloudStorage()
+
+		assert.True(t, result)
+	})
+
+	t.Run("ReturnsFalseIfLogWritersDoesNotContainCloudStorage", func(t *testing.T) {
+
+		config := APIServerConfig{
+			LogWriters: []string{
+				"database",
+			},
+		}
+
+		// act
+		result := config.WriteLogToCloudStorage()
+
+		assert.False(t, result)
+	})
+}
+
+func TestReadLogFromDatabase(t *testing.T) {
+
+	t.Run("ReturnsTrueIfLogReaderIsEmpty", func(t *testing.T) {
+
+		config := APIServerConfig{
+			LogReader: "",
+		}
+
+		// act
+		result := config.ReadLogFromDatabase()
+
+		assert.True(t, result)
+	})
+
+	t.Run("ReturnsTrueIfLogReaderEqualsDatabase", func(t *testing.T) {
+
+		config := APIServerConfig{
+			LogReader: "database",
+		}
+
+		// act
+		result := config.ReadLogFromDatabase()
+
+		assert.True(t, result)
+	})
+
+	t.Run("ReturnsFalseIfLogReaderDoesNotEqualDatabase", func(t *testing.T) {
+
+		config := APIServerConfig{
+			LogReader: "cloudstorage",
+		}
+
+		// act
+		result := config.ReadLogFromDatabase()
+
+		assert.False(t, result)
+	})
+}
+
+func TestReadLogFromCloudStorage(t *testing.T) {
+
+	t.Run("ReturnsFalseIfLogReaderIsEmpty", func(t *testing.T) {
+
+		config := APIServerConfig{
+			LogReader: "",
+		}
+
+		// act
+		result := config.ReadLogFromCloudStorage()
+
+		assert.False(t, result)
+	})
+
+	t.Run("ReturnsTrueIfLogReaderEqualsCloudStorage", func(t *testing.T) {
+
+		config := APIServerConfig{
+			LogReader: "cloudstorage",
+		}
+
+		// act
+		result := config.ReadLogFromCloudStorage()
+
+		assert.True(t, result)
+	})
+
+	t.Run("ReturnsFalseIfLogReaderDoesNotCloudStorage", func(t *testing.T) {
+
+		config := APIServerConfig{
+			LogReader: "database",
+		}
+
+		// act
+		result := config.ReadLogFromCloudStorage()
+
+		assert.False(t, result)
+	})
+}
+
+// // ReadLogFromDatabase indicates if logReader config is database
+// func (c *APIServerConfig) ReadLogFromDatabase() bool {
+// 	return c.LogReader == "database"
+// }
+
+// // ReadLogFromCloudStorage indicates if logReader config is cloudstorage
+// func (c *APIServerConfig) ReadLogFromCloudStorage() bool {
+// 	return c.LogReader == "cloudstorage"
+// }

--- a/config/test-config.yaml
+++ b/config/test-config.yaml
@@ -39,6 +39,10 @@ integrations:
 apiServer:
   baseURL: https://ci.estafette.io/
   serviceURL: http://estafette-ci-api.estafette.svc.cluster.local/
+  logWriters:
+  - database
+  - cloudstorage
+  logReader: database
 
 auth:
   iap:

--- a/config/test-config.yaml
+++ b/config/test-config.yaml
@@ -31,6 +31,11 @@ integrations:
     projectID: my-gcp-project
     dataset: my-dataset
 
+  gcs:
+    projectID: my-gcp-project
+    bucket: my-bucket
+    logsDir: /logs    
+
 apiServer:
   baseURL: https://ci.estafette.io/
   serviceURL: http://estafette-ci-api.estafette.svc.cluster.local/

--- a/estafette/estafetteApiHandler.go
+++ b/estafette/estafetteApiHandler.go
@@ -587,6 +587,17 @@ func (h *apiHandlerImpl) GetPipelineBuildLogs(c *gin.Context) {
 		return
 	}
 
+	if h.config.ReadLogFromCloudStorage() {
+		buildLogFromCloudStorage, err := h.cloudStorageClient.GetPipelineBuildLogs(ctx, *buildLog)
+		if err != nil {
+			log.Error().Err(err).
+				Msgf("Failed retrieving build logs for %v/%v/%v/builds/%v/logs from db", source, owner, repo, revisionOrID)
+			c.JSON(http.StatusInternalServerError, gin.H{"code": http.StatusText(http.StatusInternalServerError)})
+			return
+		}
+		c.JSON(http.StatusOK, buildLogFromCloudStorage)
+	}
+
 	c.JSON(http.StatusOK, buildLog)
 }
 
@@ -1070,6 +1081,17 @@ func (h *apiHandlerImpl) GetPipelineReleaseLogs(c *gin.Context) {
 	if releaseLog == nil {
 		c.JSON(http.StatusNotFound, gin.H{"code": http.StatusText(http.StatusNotFound), "message": "Pipeline release log not found"})
 		return
+	}
+
+	if h.config.ReadLogFromCloudStorage() {
+		releaseLogFromCloudStorage, err := h.cloudStorageClient.GetPipelineReleaseLogs(ctx, *releaseLog)
+		if err != nil {
+			log.Error().Err(err).
+				Msgf("Failed retrieving release logs for %v/%v/%v/%v from db", source, owner, repo, id)
+			c.JSON(http.StatusInternalServerError, gin.H{"code": http.StatusText(http.StatusInternalServerError)})
+			return
+		}
+		c.JSON(http.StatusOK, releaseLogFromCloudStorage)
 	}
 
 	c.JSON(http.StatusOK, releaseLog)

--- a/estafette/estafetteApiHandler.go
+++ b/estafette/estafetteApiHandler.go
@@ -18,6 +18,8 @@ import (
 	"github.com/estafette/estafette-ci-api/auth"
 	"github.com/estafette/estafette-ci-api/cockroach"
 	"github.com/estafette/estafette-ci-api/config"
+	"github.com/estafette/estafette-ci-api/gcs"
+	"github.com/estafette/estafette-ci-api/helpers"
 	contracts "github.com/estafette/estafette-ci-contracts"
 	crypt "github.com/estafette/estafette-ci-crypt"
 	manifest "github.com/estafette/estafette-ci-manifest"
@@ -88,6 +90,7 @@ type apiHandlerImpl struct {
 	authConfig           config.AuthConfig
 	encryptedConfig      config.APIConfig
 	cockroachDBClient    cockroach.DBClient
+	cloudStorageClient   gcs.CloudStorageClient
 	ciBuilderClient      CiBuilderClient
 	buildService         BuildService
 	warningHelper        WarningHelper
@@ -97,7 +100,7 @@ type apiHandlerImpl struct {
 }
 
 // NewAPIHandler returns a new estafette.APIHandler
-func NewAPIHandler(configFilePath string, config config.APIServerConfig, authConfig config.AuthConfig, encryptedConfig config.APIConfig, cockroachDBClient cockroach.DBClient, ciBuilderClient CiBuilderClient, buildService BuildService, warningHelper WarningHelper, secretHelper crypt.SecretHelper, githubJobVarsFunc func(context.Context, string, string, string) (string, string, error), bitbucketJobVarsFunc func(context.Context, string, string, string) (string, string, error)) (apiHandler APIHandler) {
+func NewAPIHandler(configFilePath string, config config.APIServerConfig, authConfig config.AuthConfig, encryptedConfig config.APIConfig, cockroachDBClient cockroach.DBClient, cloudStorageClient gcs.CloudStorageClient, ciBuilderClient CiBuilderClient, buildService BuildService, warningHelper WarningHelper, secretHelper crypt.SecretHelper, githubJobVarsFunc func(context.Context, string, string, string) (string, string, error), bitbucketJobVarsFunc func(context.Context, string, string, string) (string, string, error)) (apiHandler APIHandler) {
 
 	apiHandler = &apiHandlerImpl{
 		configFilePath:       configFilePath,
@@ -105,6 +108,7 @@ func NewAPIHandler(configFilePath string, config config.APIServerConfig, authCon
 		authConfig:           authConfig,
 		encryptedConfig:      encryptedConfig,
 		cockroachDBClient:    cockroachDBClient,
+		cloudStorageClient:   cloudStorageClient,
 		ciBuilderClient:      ciBuilderClient,
 		buildService:         buildService,
 		warningHelper:        warningHelper,
@@ -659,10 +663,18 @@ func (h *apiHandlerImpl) PostPipelineBuildLogs(c *gin.Context) {
 		buildLog.BuildID = revisionOrID
 	}
 
-	err = h.cockroachDBClient.InsertBuildLog(ctx, buildLog)
+	insertedBuildLog, err := h.cockroachDBClient.InsertBuildLog(ctx, buildLog, h.config.WriteLogToDatabase())
 	if err != nil {
 		log.Error().Err(err).
 			Msgf("Failed inserting logs for %v/%v/%v/%v", source, owner, repo, revisionOrID)
+	}
+
+	if h.config.WriteLogToCloudStorage() {
+		err = h.cloudStorageClient.InsertBuildLog(ctx, insertedBuildLog)
+		if err != nil {
+			log.Error().Err(err).
+				Msgf("Failed inserting logs into cloudstorage for %v/%v/%v/%v", source, owner, repo, revisionOrID)
+		}
 	}
 
 	c.String(http.StatusOK, "Aye aye!")
@@ -1133,10 +1145,18 @@ func (h *apiHandlerImpl) PostPipelineReleaseLogs(c *gin.Context) {
 		return
 	}
 
-	err = h.cockroachDBClient.InsertReleaseLog(ctx, releaseLog)
+	insertedReleaseLog, err := h.cockroachDBClient.InsertReleaseLog(ctx, releaseLog, h.config.WriteLogToDatabase())
 	if err != nil {
 		log.Error().Err(err).
 			Msgf("Failed inserting release logs for %v/%v/%v/%v", source, owner, repo, id)
+	}
+
+	if h.config.WriteLogToCloudStorage() {
+		err = h.cloudStorageClient.InsertReleaseLog(ctx, insertedReleaseLog)
+		if err != nil {
+			log.Error().Err(err).
+				Msgf("Failed inserting release logs into cloud storage for %v/%v/%v/%v", source, owner, repo, id)
+		}
 	}
 
 	c.String(http.StatusOK, "Aye aye!")
@@ -1857,7 +1877,7 @@ func (h *apiHandlerImpl) GetManifestTemplates(c *gin.Context) {
 			// reduce and deduplicate [["{{.Application}}","Application"],["{{.Team}}","Team"],["{{.ProjectName}}","ProjectName"],["{{.ProjectName}}","ProjectName"]] to ["Application","Team","ProjectName"]
 			placeholders := []string{}
 			for _, m := range placeholderMatches {
-				if len(m) == 2 && !stringArrayContains(placeholders, m[1]) {
+				if len(m) == 2 && !helpers.StringArrayContains(placeholders, m[1]) {
 					placeholders = append(placeholders, m[1])
 				}
 			}
@@ -1872,15 +1892,6 @@ func (h *apiHandlerImpl) GetManifestTemplates(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"templates": templates})
-}
-
-func stringArrayContains(array []string, value string) bool {
-	for _, v := range array {
-		if v == value {
-			return true
-		}
-	}
-	return false
 }
 
 func (h *apiHandlerImpl) GenerateManifest(c *gin.Context) {

--- a/gcs/cloudStorageClient.go
+++ b/gcs/cloudStorageClient.go
@@ -1,0 +1,39 @@
+package gcs
+
+import (
+	"context"
+
+	"cloud.google.com/go/storage"
+	"github.com/estafette/estafette-ci-api/config"
+)
+
+// CloudStorageClient is the interface for connecting to google cloud storage
+type CloudStorageClient interface {
+}
+
+type cloudStorageClientImpl struct {
+	client *storage.Client
+	config *config.CloudStorageConfig
+}
+
+// NewCloudStorageClient returns new CloudStorageClient
+func NewCloudStorageClient(config *config.CloudStorageConfig) (CloudStorageClient, error) {
+
+	if config == nil {
+		return &cloudStorageClientImpl{
+			config: config,
+		}, nil
+	}
+
+	ctx := context.Background()
+
+	storageClient, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cloudStorageClientImpl{
+		client: storageClient,
+		config: config,
+	}, nil
+}

--- a/gcs/cloudStorageClient.go
+++ b/gcs/cloudStorageClient.go
@@ -10,6 +10,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/estafette/estafette-ci-api/config"
 	contracts "github.com/estafette/estafette-ci-contracts"
+	"github.com/opentracing/opentracing-go"
 )
 
 // CloudStorageClient is the interface for connecting to google cloud storage
@@ -49,6 +50,9 @@ func NewCloudStorageClient(config *config.CloudStorageConfig) (CloudStorageClien
 
 func (impl *cloudStorageClientImpl) InsertBuildLog(ctx context.Context, buildLog contracts.BuildLog) (err error) {
 
+	span, ctx := opentracing.StartSpanFromContext(ctx, "CloudStorageClient::InsertBuildLog")
+	defer span.Finish()
+
 	logPath := impl.getBuildLogPath(buildLog)
 
 	return impl.insertLog(ctx, logPath, buildLog.Steps)
@@ -56,12 +60,18 @@ func (impl *cloudStorageClientImpl) InsertBuildLog(ctx context.Context, buildLog
 
 func (impl *cloudStorageClientImpl) InsertReleaseLog(ctx context.Context, releaseLog contracts.ReleaseLog) (err error) {
 
+	span, ctx := opentracing.StartSpanFromContext(ctx, "CloudStorageClient::InsertReleaseLog")
+	defer span.Finish()
+
 	logPath := impl.getReleaseLogPath(releaseLog)
 
 	return impl.insertLog(ctx, logPath, releaseLog.Steps)
 }
 
 func (impl *cloudStorageClientImpl) GetPipelineBuildLogs(ctx context.Context, buildLog contracts.BuildLog) (updatedBuildLog contracts.BuildLog, err error) {
+
+	span, ctx := opentracing.StartSpanFromContext(ctx, "CloudStorageClient::GetPipelineBuildLogs")
+	defer span.Finish()
 
 	logPath := impl.getBuildLogPath(buildLog)
 
@@ -77,6 +87,9 @@ func (impl *cloudStorageClientImpl) GetPipelineBuildLogs(ctx context.Context, bu
 }
 
 func (impl *cloudStorageClientImpl) GetPipelineReleaseLogs(ctx context.Context, releaseLog contracts.ReleaseLog) (updatedReleaseLog contracts.ReleaseLog, err error) {
+
+	span, ctx := opentracing.StartSpanFromContext(ctx, "CloudStorageClient::GetPipelineReleaseLogs")
+	defer span.Finish()
 
 	logPath := impl.getReleaseLogPath(releaseLog)
 

--- a/gcs/cloudStorageClient.go
+++ b/gcs/cloudStorageClient.go
@@ -1,14 +1,23 @@
 package gcs
 
 import (
+	"compress/gzip"
 	"context"
+	"encoding/json"
+	"fmt"
+	"path"
 
 	"cloud.google.com/go/storage"
 	"github.com/estafette/estafette-ci-api/config"
+	contracts "github.com/estafette/estafette-ci-contracts"
 )
 
 // CloudStorageClient is the interface for connecting to google cloud storage
 type CloudStorageClient interface {
+	InsertBuildLog(ctx context.Context, buildLog contracts.BuildLog) (err error)
+	InsertReleaseLog(ctx context.Context, releaseLog contracts.ReleaseLog) (err error)
+	GetPipelineBuildLogs(ctx context.Context, buildLog contracts.BuildLog) (updatedBuildLog contracts.BuildLog, err error)
+	GetPipelineReleaseLogs(ctx context.Context, releaseLog contracts.ReleaseLog) (updatedReleaseLog contracts.ReleaseLog, err error)
 }
 
 type cloudStorageClientImpl struct {
@@ -36,4 +45,142 @@ func NewCloudStorageClient(config *config.CloudStorageConfig) (CloudStorageClien
 		client: storageClient,
 		config: config,
 	}, nil
+}
+
+func (impl *cloudStorageClientImpl) InsertBuildLog(ctx context.Context, buildLog contracts.BuildLog) (err error) {
+
+	logPath := impl.getBuildLogPath(buildLog)
+
+	return impl.insertLog(ctx, logPath, buildLog.Steps)
+}
+
+func (impl *cloudStorageClientImpl) InsertReleaseLog(ctx context.Context, releaseLog contracts.ReleaseLog) (err error) {
+
+	logPath := impl.getReleaseLogPath(releaseLog)
+
+	return impl.insertLog(ctx, logPath, releaseLog.Steps)
+}
+
+func (impl *cloudStorageClientImpl) GetPipelineBuildLogs(ctx context.Context, buildLog contracts.BuildLog) (updatedBuildLog contracts.BuildLog, err error) {
+
+	logPath := impl.getBuildLogPath(buildLog)
+
+	steps, err := impl.getLog(ctx, logPath)
+	if err != nil {
+		return buildLog, err
+	}
+
+	updatedBuildLog = buildLog
+	updatedBuildLog.Steps = steps
+
+	return updatedBuildLog, nil
+}
+
+func (impl *cloudStorageClientImpl) GetPipelineReleaseLogs(ctx context.Context, releaseLog contracts.ReleaseLog) (updatedReleaseLog contracts.ReleaseLog, err error) {
+
+	logPath := impl.getReleaseLogPath(releaseLog)
+
+	steps, err := impl.getLog(ctx, logPath)
+	if err != nil {
+		return releaseLog, err
+	}
+
+	updatedReleaseLog = releaseLog
+	updatedReleaseLog.Steps = steps
+
+	return updatedReleaseLog, nil
+
+}
+
+func (impl *cloudStorageClientImpl) insertLog(ctx context.Context, path string, steps []*contracts.BuildLogStep) (err error) {
+
+	bucket := impl.client.Bucket(impl.config.Bucket)
+
+	// marshal json
+	jsonBytes, err := json.Marshal(steps)
+	if err != nil {
+		return err
+	}
+
+	// create writer for cloud storage object
+	logObject := bucket.Object(path)
+	writer := logObject.NewWriter(ctx)
+	if writer == nil {
+		return fmt.Errorf("Writer for logobject %v is nil", path)
+	}
+	defer writer.Close()
+
+	// write compressed bytes
+	gz := gzip.NewWriter(writer)
+	_, err = gz.Write(jsonBytes)
+	if err != nil {
+		_ = writer.Close()
+		return err
+	}
+	err = gz.Close()
+	if err != nil {
+		_ = writer.Close()
+		return err
+	}
+	err = writer.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (impl *cloudStorageClientImpl) getLog(ctx context.Context, path string) (steps []*contracts.BuildLogStep, err error) {
+
+	bucket := impl.client.Bucket(impl.config.Bucket)
+
+	// create reader for cloud storage object
+	logObject := bucket.Object(path)
+	reader, err := logObject.NewReader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if reader == nil {
+		return nil, fmt.Errorf("Writer for logobject %v is nil", path)
+	}
+
+	// read compressed bytes
+	var jsonBytes []byte
+	gz, err := gzip.NewReader(reader)
+	_, err = gz.Read(jsonBytes)
+	if err != nil {
+		_ = reader.Close()
+		return nil, err
+	}
+	err = gz.Close()
+	if err != nil {
+		_ = reader.Close()
+		return nil, err
+	}
+	err = reader.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	// unmarshal json
+	err = json.Unmarshal(jsonBytes, &steps)
+	if err != nil {
+		return nil, err
+	}
+
+	return
+}
+
+func (impl *cloudStorageClientImpl) getBuildLogPath(buildLog contracts.BuildLog) (logPath string) {
+
+	logPath = path.Join(impl.config.LogsDirectory, buildLog.RepoSource, buildLog.RepoOwner, buildLog.RepoName, "builds", fmt.Sprintf("%v.log", buildLog.ID))
+
+	return logPath
+}
+
+func (impl *cloudStorageClientImpl) getReleaseLogPath(releaseLog contracts.ReleaseLog) (logPath string) {
+
+	logPath = path.Join(impl.config.LogsDirectory, releaseLog.RepoSource, releaseLog.RepoOwner, releaseLog.RepoName, "releases", fmt.Sprintf("%v.log", releaseLog.ID))
+
+	return logPath
 }

--- a/gke/config.yaml
+++ b/gke/config.yaml
@@ -48,6 +48,10 @@ integrations:
 apiServer:
   baseURL: https://{{.HOSTNAMES}}/
   serviceURL: https://{{.INTERNAL_HOSTNAME}}/
+  logWriters:
+  - database
+  - cloudstorage
+  logReader: database
 
 auth:
   iap:

--- a/gke/config.yaml
+++ b/gke/config.yaml
@@ -40,6 +40,11 @@ integrations:
     projectID: {{.BIGQUERY_PROJECT}}
     dataset: {{.BIGQUERY_DATASET}}
 
+  gcs:
+    projectID: {{.GCS_PROJECT}}
+    bucket: {{.GCS_BUCKET}}
+    logsDir: /logs
+
 apiServer:
   baseURL: https://{{.HOSTNAMES}}/
   serviceURL: https://{{.INTERNAL_HOSTNAME}}/

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	cloud.google.com/go/bigquery v1.0.1
 	cloud.google.com/go/pubsub v1.0.1
-	cloud.google.com/go/storage v1.0.0 // indirect
+	cloud.google.com/go/storage v1.0.0
 	github.com/Masterminds/squirrel v1.1.0
 	github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38 // indirect
 	github.com/alecthomas/colour v0.0.0-20160524082231-60882d9e2721 // indirect

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -1,0 +1,11 @@
+package helpers
+
+// StringArrayContains returns true of a value is present in the array
+func StringArrayContains(array []string, value string) bool {
+	for _, v := range array {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
With this it's possible to specify multiple log writers so for a while we can write to both database and cloud storage; a single reader can be specified. If writing to cloud storage works we need to migrate historic logs before we can switch to reading from gcs.