### PR TITLE
Extend pubsub push message with attribute with topicId

### DIFF
--- a/pubsub/contracts/pubsubDomain.go
+++ b/pubsub/contracts/pubsubDomain.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"encoding/base64"
+	"fmt"
 	"strings"
 )
 
@@ -33,4 +34,19 @@ func (m PubSubPushMessage) GetDecodedData() string {
 		return m.Message.Data
 	}
 	return string(data)
+}
+
+// GetTopic returns TopicID. Expects Topic set in attributes of the message
+func (m PubSubPushMessage) GetTopic(topicAttributeName string) (string, error) {
+
+	if m.Message.Attributes == nil {
+		return "", fmt.Errorf("Attribute '%v' is not found in pubsub message. Attributes are nil", topicAttributeName)
+	}
+
+	topicID, ok := (*m.Message.Attributes)[topicAttributeName]
+	if !ok {
+		return "", fmt.Errorf("Attribute '%v' is not found in pubsub message. Attributes: %v", topicAttributeName, (*m.Message.Attributes))
+	}
+
+	return topicID, nil
 }

--- a/pubsub/pubsubApiClient.go
+++ b/pubsub/pubsubApiClient.go
@@ -21,7 +21,7 @@ type APIClient interface {
 	SubscribeToPubsubTriggers(ctx context.Context, manifestString string) error
 }
 
-var topicAttributeName = "topic"
+const topicAttributeName = "topic"
 
 type apiClient struct {
 	config       config.PubsubConfig


### PR DESCRIPTION
For cross-project subscriptions topic can't be evaluated from subscription only.
Now it is passed in pubsub message attributes with name "topic" and topicID as a value