### PR TITLE
Extend pubsub push message with attribute with project name

### DIFF
--- a/pubsub/contracts/pubsubDomain.go
+++ b/pubsub/contracts/pubsubDomain.go
@@ -2,7 +2,6 @@ package contracts
 
 import (
 	"encoding/base64"
-	"fmt"
 	"strings"
 )
 
@@ -34,19 +33,4 @@ func (m PubSubPushMessage) GetDecodedData() string {
 		return m.Message.Data
 	}
 	return string(data)
-}
-
-// GetTopic returns TopicID. Expects Topic set in attributes of the message
-func (m PubSubPushMessage) GetTopic(topicAttributeName string) (string, error) {
-
-	if m.Message.Attributes == nil {
-		return "", fmt.Errorf("Attribute '%v' is not found in pubsub message. Attributes are nil", topicAttributeName)
-	}
-
-	topicID, ok := (*m.Message.Attributes)[topicAttributeName]
-	if !ok {
-		return "", fmt.Errorf("Attribute '%v' is not found in pubsub message. Attributes: %v", topicAttributeName, (*m.Message.Attributes))
-	}
-
-	return topicID, nil
 }

--- a/pubsub/contracts/pubsubDomain.go
+++ b/pubsub/contracts/pubsubDomain.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"encoding/base64"
+	"fmt"
 	"strings"
 )
 
@@ -33,4 +34,19 @@ func (m PubSubPushMessage) GetDecodedData() string {
 		return m.Message.Data
 	}
 	return string(data)
+}
+
+// GetTopic returns TopicID. Expects Topic set in attributes of the message
+func (m PubSubPushMessage) GetTopic(topicAttributeName string) (string, error) {
+
+	if m.Message.Attributes == nil {
+		return "", fmt.Errorf("Attribute '%v' is not found in pubsub message. Attributes are nil", topicAttributeName)
+	}
+
+	topicID, ok := (*m.Message.Attributes)[topicAttributeName]
+	if !ok {
+		return "", fmt.Errorf("Attribute '%v' is not found in pubsub message. Attributes: %v", topicAttributeName, (*m.Message.Attributes))
+	}
+
+	return topicID, nil
 }

--- a/pubsub/contracts/pubsubDomain.go
+++ b/pubsub/contracts/pubsubDomain.go
@@ -16,20 +16,26 @@ type PubSubPushMessage struct {
 	Subscription string `json:"subscription,omitempty"`
 }
 
-// GetProject returns the project id for the pubsub subscription
-func (m PubSubPushMessage) GetProject(topicProjectAttributeName string) string {
-	var projectNameFromSubscription = strings.Split(m.Subscription, "/")[1]
+// GetTopicProject returns the project id which owns the topic
+func (m PubSubPushMessage) GetTopicProject(topicProjectAttributeName string) string {
+	var subscriptionProject = m.GetSubscriptionProject()
 
-	if m.Message.Attributes == nil {
-		return projectNameFromSubscription
+	attributes := m.GetAttributes()
+	if attributes == nil {
+		return subscriptionProject
 	}
 
-	projectNameFromAttribute, ok := (*m.Message.Attributes)[topicProjectAttributeName]
-	if !ok || len(projectNameFromAttribute) == 0 {
-		return projectNameFromSubscription
+	topicOwnerProject, ok := attributes[topicProjectAttributeName]
+	if !ok || len(topicOwnerProject) == 0 {
+		return subscriptionProject
 	}
 
-	return projectNameFromAttribute
+	return topicOwnerProject
+}
+
+// GetSubscriptionProject returns the project id for the pubsub subscription
+func (m PubSubPushMessage) GetSubscriptionProject() string {
+	return strings.Split(m.Subscription, "/")[1]
 }
 
 // GetSubscription returns the subscription name
@@ -44,4 +50,13 @@ func (m PubSubPushMessage) GetDecodedData() string {
 		return m.Message.Data
 	}
 	return string(data)
+}
+
+// GetAttributes returns the attributes of the message
+func (m PubSubPushMessage) GetAttributes() map[string]string {
+	if m.Message.Attributes == nil {
+		return nil
+	}
+
+	return (*m.Message.Attributes)
 }

--- a/pubsub/contracts/pubsubDomain.go
+++ b/pubsub/contracts/pubsubDomain.go
@@ -25,12 +25,12 @@ func (m PubSubPushMessage) GetTopicProject(topicProjectAttributeName string) str
 		return subscriptionProject
 	}
 
-	topicOwnerProject, ok := attributes[topicProjectAttributeName]
-	if !ok || len(topicOwnerProject) == 0 {
+	topicProject, ok := attributes[topicProjectAttributeName]
+	if !ok || len(topicProject) == 0 {
 		return subscriptionProject
 	}
 
-	return topicOwnerProject
+	return topicProject
 }
 
 // GetSubscriptionProject returns the project id for the pubsub subscription

--- a/pubsub/contracts/pubsubDomain.go
+++ b/pubsub/contracts/pubsubDomain.go
@@ -17,8 +17,19 @@ type PubSubPushMessage struct {
 }
 
 // GetProject returns the project id for the pubsub subscription
-func (m PubSubPushMessage) GetProject() string {
-	return strings.Split(m.Subscription, "/")[1]
+func (m PubSubPushMessage) GetProject(topicProjectAttributeName string) string {
+	var projectNameFromSubscription = strings.Split(m.Subscription, "/")[1]
+
+	if m.Message.Attributes == nil {
+		return projectNameFromSubscription
+	}
+
+	projectNameFromAttribute, ok := (*m.Message.Attributes)[topicProjectAttributeName]
+	if !ok || len(projectNameFromAttribute) == 0 {
+		return projectNameFromSubscription
+	}
+
+	return projectNameFromAttribute
 }
 
 // GetSubscription returns the subscription name

--- a/pubsub/pubsubApiClient.go
+++ b/pubsub/pubsubApiClient.go
@@ -21,7 +21,7 @@ type APIClient interface {
 	SubscribeToPubsubTriggers(ctx context.Context, manifestString string) error
 }
 
-const topicAttributeName = "topic"
+var topicAttributeName = "topic"
 
 type apiClient struct {
 	config       config.PubsubConfig

--- a/pubsub/pubsubApiClient.go
+++ b/pubsub/pubsubApiClient.go
@@ -21,7 +21,7 @@ type APIClient interface {
 	SubscribeToPubsubTriggers(ctx context.Context, manifestString string) error
 }
 
-var topicAttributeName = "topic"
+const topicAttributeName = "topic"
 
 type apiClient struct {
 	config       config.PubsubConfig

--- a/pubsub/pubsubEventHandler.go
+++ b/pubsub/pubsubEventHandler.go
@@ -1,6 +1,7 @@
 package pubsub
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/estafette/estafette-ci-api/estafette"
@@ -61,7 +62,8 @@ func (eh *eventHandler) PostPubsubEvent(c *gin.Context) {
 	log.Info().
 		Interface("msg", message).
 		Str("data", message.GetDecodedData()).
-		Str("project", message.GetProject()).
+		Str("subscriptionProject", message.GetSubscriptionProject()).
+		Str("attributes", fmt.Sprintf("%v", message.GetAttributes())).
 		Str("subscription", message.GetSubscription()).
 		Str("topic", pubsubEvent.Topic).
 		Msg("Successfully binded pubsub push event")


### PR DESCRIPTION
For cross-project subscriptions, topic can be in projectA, but subscription will be in projectB.
it means, topic project should be passed in the message or somehow evaluated in the cloud.

I didn't find a convenient method to :
1. Find a topic by subscription name
2. Identify a project of the topic

It looks like, passing an attribute with project name in pubsub message is the easiest option.

Additionally, I separated methods for subscription project and topic project to highlight the difference