### PR TITLE
Separate topic project and subscription project for pubsub messages

### DIFF
--- a/pubsub/contracts/pubsubDomain.go
+++ b/pubsub/contracts/pubsubDomain.go
@@ -16,13 +16,13 @@ type PubSubPushMessage struct {
 	Subscription string `json:"subscription,omitempty"`
 }
 
-// GetProject returns the project id for the pubsub subscription
-func (m PubSubPushMessage) GetProject() string {
+// GetSubscriptionProject returns the project id for the subscription
+func (m PubSubPushMessage) GetSubscriptionProject() string {
 	return strings.Split(m.Subscription, "/")[1]
 }
 
-// GetSubscription returns the subscription name
-func (m PubSubPushMessage) GetSubscription() string {
+// GetSubscriptionID returns the unique identifier of the subscription within its project.
+func (m PubSubPushMessage) GetSubscriptionID() string {
 	return strings.Split(m.Subscription, "/")[3]
 }
 

--- a/pubsub/pubsubEventHandler.go
+++ b/pubsub/pubsubEventHandler.go
@@ -61,8 +61,9 @@ func (eh *eventHandler) PostPubsubEvent(c *gin.Context) {
 	log.Info().
 		Interface("msg", message).
 		Str("data", message.GetDecodedData()).
-		Str("project", message.GetProject()).
-		Str("subscription", message.GetSubscription()).
+		Str("subscriptionProject", message.GetSubscriptionProject()).
+		Str("subscription", message.GetSubscriptionID()).
+		Str("topicProject", pubsubEvent.Project).
 		Str("topic", pubsubEvent.Topic).
 		Msg("Successfully binded pubsub push event")
 


### PR DESCRIPTION
For cross-project subscriptions, topic can be in projectA, but subscription can be in projectB.
At the same time, estafette searches for triggers by full topic name.

It means, for each message I have to retrieve subscription configuration and get both topicID and topic project form there