### PR TITLE
Use topic for publishing and subscribing git trigger events

### DIFF
--- a/services/bitbucket/service.go
+++ b/services/bitbucket/service.go
@@ -62,14 +62,6 @@ func (s *service) CreateJobForBitbucketPush(ctx context.Context, pushEvent bitbu
 
 	// handle git triggers
 	s.gitEventTopic.Publish("bitbucket.Service", topics.GitEventTopicMessage{Ctx: ctx, Event: gitEvent})
-	// go func() {
-	// 	err := s.estafetteService.FireGitTriggers(ctx, gitEvent)
-	// 	if err != nil {
-	// 		log.Error().Err(err).
-	// 			Interface("gitEvent", gitEvent).
-	// 			Msg("Failed firing git triggers")
-	// 	}
-	// }()
 
 	// get access token
 	accessToken, err := s.bitbucketapiClient.GetAccessToken(ctx)

--- a/services/cloudsource/service.go
+++ b/services/cloudsource/service.go
@@ -76,14 +76,6 @@ func (s *service) CreateJobForCloudSourcePush(ctx context.Context, notification 
 
 	// handle git triggers
 	s.gitEventTopic.Publish("cloudsource.Service", topics.GitEventTopicMessage{Ctx: ctx, Event: gitEvent})
-	// go func() {
-	// 	err := s.estafetteService.FireGitTriggers(ctx, gitEvent)
-	// 	if err != nil {
-	// 		log.Error().Err(err).
-	// 			Interface("gitEvent", gitEvent).
-	// 			Msg("Failed firing git triggers")
-	// 	}
-	// }()
 
 	// get access token
 	accessToken, err := s.cloudsourceapiClient.GetAccessToken(ctx)

--- a/services/estafette/logging.go
+++ b/services/estafette/logging.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/estafette/estafette-ci-api/clients/builderapi"
 	"github.com/estafette/estafette-ci-api/helpers"
+	"github.com/estafette/estafette-ci-api/topics"
 	contracts "github.com/estafette/estafette-ci-contracts"
 	manifest "github.com/estafette/estafette-ci-manifest"
 )
@@ -101,4 +102,8 @@ func (s *loggingService) UpdateJobResources(ctx context.Context, event builderap
 	defer func() { helpers.HandleLogError(s.prefix, "UpdateJobResources", err) }()
 
 	return s.Service.UpdateJobResources(ctx, event)
+}
+
+func (s *loggingService) SubscribeToGitEventsTopic(ctx context.Context, gitEventTopic *topics.GitEventTopic) {
+	s.Service.SubscribeToGitEventsTopic(ctx, gitEventTopic)
 }

--- a/services/estafette/metrics.go
+++ b/services/estafette/metrics.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/estafette/estafette-ci-api/clients/builderapi"
 	"github.com/estafette/estafette-ci-api/helpers"
+	"github.com/estafette/estafette-ci-api/topics"
 	contracts "github.com/estafette/estafette-ci-contracts"
 	manifest "github.com/estafette/estafette-ci-manifest"
 	"github.com/go-kit/kit/metrics"
@@ -118,4 +119,12 @@ func (s *metricsService) UpdateJobResources(ctx context.Context, event builderap
 	}(time.Now())
 
 	return s.Service.UpdateJobResources(ctx, event)
+}
+
+func (s *metricsService) SubscribeToGitEventsTopic(ctx context.Context, gitEventTopic *topics.GitEventTopic) {
+	defer func(begin time.Time) {
+		helpers.UpdateMetrics(s.requestCount, s.requestLatency, "SubscribeToGitEventsTopic", begin)
+	}(time.Now())
+
+	s.Service.SubscribeToGitEventsTopic(ctx, gitEventTopic)
 }

--- a/services/estafette/mock.go
+++ b/services/estafette/mock.go
@@ -4,25 +4,27 @@ import (
 	"context"
 
 	"github.com/estafette/estafette-ci-api/clients/builderapi"
+	"github.com/estafette/estafette-ci-api/topics"
 	contracts "github.com/estafette/estafette-ci-contracts"
 	manifest "github.com/estafette/estafette-ci-manifest"
 )
 
 type MockService struct {
-	CreateBuildFunc          func(ctx context.Context, build contracts.Build, waitForJobToStart bool) (b *contracts.Build, err error)
-	FinishBuildFunc          func(ctx context.Context, repoSource, repoOwner, repoName string, buildID int, buildStatus string) (err error)
-	CreateReleaseFunc        func(ctx context.Context, release contracts.Release, mft manifest.EstafetteManifest, repoBranch, repoRevision string, waitForJobToStart bool) (r *contracts.Release, err error)
-	FinishReleaseFunc        func(ctx context.Context, repoSource, repoOwner, repoName string, releaseID int, releaseStatus string) (err error)
-	FireGitTriggersFunc      func(ctx context.Context, gitEvent manifest.EstafetteGitEvent) (err error)
-	FirePipelineTriggersFunc func(ctx context.Context, build contracts.Build, event string) (err error)
-	FireReleaseTriggersFunc  func(ctx context.Context, release contracts.Release, event string) (err error)
-	FirePubSubTriggersFunc   func(ctx context.Context, pubsubEvent manifest.EstafettePubSubEvent) (err error)
-	FireCronTriggersFunc     func(ctx context.Context) (err error)
-	RenameFunc               func(ctx context.Context, fromRepoSource, fromRepoOwner, fromRepoName, toRepoSource, toRepoOwner, toRepoName string) (err error)
-	ArchiveFunc              func(ctx context.Context, repoSource, repoOwner, repoName string) (err error)
-	UnarchiveFunc            func(ctx context.Context, repoSource, repoOwner, repoName string) (err error)
-	UpdateBuildStatusFunc    func(ctx context.Context, event builderapi.CiBuilderEvent) (err error)
-	UpdateJobResourcesFunc   func(ctx context.Context, event builderapi.CiBuilderEvent) (err error)
+	CreateBuildFunc               func(ctx context.Context, build contracts.Build, waitForJobToStart bool) (b *contracts.Build, err error)
+	FinishBuildFunc               func(ctx context.Context, repoSource, repoOwner, repoName string, buildID int, buildStatus string) (err error)
+	CreateReleaseFunc             func(ctx context.Context, release contracts.Release, mft manifest.EstafetteManifest, repoBranch, repoRevision string, waitForJobToStart bool) (r *contracts.Release, err error)
+	FinishReleaseFunc             func(ctx context.Context, repoSource, repoOwner, repoName string, releaseID int, releaseStatus string) (err error)
+	FireGitTriggersFunc           func(ctx context.Context, gitEvent manifest.EstafetteGitEvent) (err error)
+	FirePipelineTriggersFunc      func(ctx context.Context, build contracts.Build, event string) (err error)
+	FireReleaseTriggersFunc       func(ctx context.Context, release contracts.Release, event string) (err error)
+	FirePubSubTriggersFunc        func(ctx context.Context, pubsubEvent manifest.EstafettePubSubEvent) (err error)
+	FireCronTriggersFunc          func(ctx context.Context) (err error)
+	RenameFunc                    func(ctx context.Context, fromRepoSource, fromRepoOwner, fromRepoName, toRepoSource, toRepoOwner, toRepoName string) (err error)
+	ArchiveFunc                   func(ctx context.Context, repoSource, repoOwner, repoName string) (err error)
+	UnarchiveFunc                 func(ctx context.Context, repoSource, repoOwner, repoName string) (err error)
+	UpdateBuildStatusFunc         func(ctx context.Context, event builderapi.CiBuilderEvent) (err error)
+	UpdateJobResourcesFunc        func(ctx context.Context, event builderapi.CiBuilderEvent) (err error)
+	SubscribeToGitEventsTopicFunc func(ctx context.Context, gitEventTopic *topics.GitEventTopic)
 }
 
 func (s MockService) CreateBuild(ctx context.Context, build contracts.Build, waitForJobToStart bool) (b *contracts.Build, err error) {
@@ -121,4 +123,10 @@ func (s MockService) UpdateJobResources(ctx context.Context, event builderapi.Ci
 		return
 	}
 	return s.UpdateJobResourcesFunc(ctx, event)
+}
+
+func (s MockService) SubscribeToGitEventsTopic(ctx context.Context, gitEventTopic *topics.GitEventTopic) {
+	if s.SubscribeToGitEventsTopicFunc != nil {
+		s.SubscribeToGitEventsTopicFunc(ctx, gitEventTopic)
+	}
 }

--- a/services/estafette/tracing.go
+++ b/services/estafette/tracing.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/estafette/estafette-ci-api/clients/builderapi"
 	"github.com/estafette/estafette-ci-api/helpers"
+	"github.com/estafette/estafette-ci-api/topics"
 	contracts "github.com/estafette/estafette-ci-contracts"
 	manifest "github.com/estafette/estafette-ci-manifest"
 	"github.com/opentracing/opentracing-go"
@@ -116,4 +117,11 @@ func (s *tracingService) UpdateJobResources(ctx context.Context, event builderap
 	defer func() { helpers.FinishSpanWithError(span, err) }()
 
 	return s.Service.UpdateJobResources(ctx, event)
+}
+
+func (s *tracingService) SubscribeToGitEventsTopic(ctx context.Context, gitEventTopic *topics.GitEventTopic) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, helpers.GetSpanName(s.prefix, "SubscribeToGitEventsTopic"))
+	defer func() { helpers.FinishSpan(span) }()
+
+	s.Service.SubscribeToGitEventsTopic(ctx, gitEventTopic)
 }

--- a/services/github/service.go
+++ b/services/github/service.go
@@ -67,14 +67,6 @@ func (s *service) CreateJobForGithubPush(ctx context.Context, pushEvent githubap
 
 	// handle git triggers
 	s.gitEventTopic.Publish("github.Service", topics.GitEventTopicMessage{Ctx: ctx, Event: gitEvent})
-	// go func() {
-	// 	err := s.estafetteService.FireGitTriggers(ctx, gitEvent)
-	// 	if err != nil {
-	// 		log.Error().Err(err).
-	// 			Interface("gitEvent", gitEvent).
-	// 			Msg("Failed firing git triggers")
-	// 	}
-	// }()
 
 	// get access token
 	accessToken, err := s.githubapiClient.GetInstallationToken(ctx, pushEvent.Installation.ID)

--- a/services/github/service.go
+++ b/services/github/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/estafette/estafette-ci-api/clients/pubsubapi"
 	"github.com/estafette/estafette-ci-api/config"
 	"github.com/estafette/estafette-ci-api/services/estafette"
+	"github.com/estafette/estafette-ci-api/topics"
 	contracts "github.com/estafette/estafette-ci-contracts"
 	manifest "github.com/estafette/estafette-ci-manifest"
 	"github.com/rs/zerolog/log"
@@ -33,12 +34,13 @@ type Service interface {
 }
 
 // NewService returns a github.Service to handle incoming webhook events
-func NewService(config *config.APIConfig, githubapiClient githubapi.Client, pubsubapiClient pubsubapi.Client, estafetteService estafette.Service) Service {
+func NewService(config *config.APIConfig, githubapiClient githubapi.Client, pubsubapiClient pubsubapi.Client, estafetteService estafette.Service, gitEventTopic *topics.GitEventTopic) Service {
 	return &service{
 		githubapiClient:  githubapiClient,
 		pubsubapiClient:  pubsubapiClient,
 		estafetteService: estafetteService,
 		config:           config,
+		gitEventTopic:    gitEventTopic,
 	}
 }
 
@@ -47,6 +49,7 @@ type service struct {
 	pubsubapiClient  pubsubapi.Client
 	estafetteService estafette.Service
 	config           *config.APIConfig
+	gitEventTopic    *topics.GitEventTopic
 }
 
 func (s *service) CreateJobForGithubPush(ctx context.Context, pushEvent githubapi.PushEvent) (err error) {
@@ -63,14 +66,15 @@ func (s *service) CreateJobForGithubPush(ctx context.Context, pushEvent githubap
 	}
 
 	// handle git triggers
-	go func() {
-		err := s.estafetteService.FireGitTriggers(ctx, gitEvent)
-		if err != nil {
-			log.Error().Err(err).
-				Interface("gitEvent", gitEvent).
-				Msg("Failed firing git triggers")
-		}
-	}()
+	s.gitEventTopic.Publish("github.Service", topics.GitEventTopicMessage{Ctx: ctx, Event: gitEvent})
+	// go func() {
+	// 	err := s.estafetteService.FireGitTriggers(ctx, gitEvent)
+	// 	if err != nil {
+	// 		log.Error().Err(err).
+	// 			Interface("gitEvent", gitEvent).
+	// 			Msg("Failed firing git triggers")
+	// 	}
+	// }()
 
 	// get access token
 	accessToken, err := s.githubapiClient.GetInstallationToken(ctx, pushEvent.Installation.ID)

--- a/services/github/service_test.go
+++ b/services/github/service_test.go
@@ -149,7 +149,7 @@ func TestCreateJobForGithubPush(t *testing.T) {
 		defer gitEventTopic.Close()
 		subscriptionChannel := gitEventTopic.Subscribe("PublishesGitTriggersOnTopic")
 
-		service := NewService(config, githubapiClient, pubsubapiClient, estafetteService, e, gitEventTopic)
+		service := NewService(config, githubapiClient, pubsubapiClient, estafetteService, gitEventTopic)
 
 		pushEvent := githubapi.PushEvent{
 			Ref: "refs/heads/master",

--- a/topics/buildTopic.go
+++ b/topics/buildTopic.go
@@ -1,0 +1,86 @@
+package topics
+
+import (
+	"context"
+	"sync"
+
+	"github.com/estafette/estafette-ci-api/helpers"
+	contracts "github.com/estafette/estafette-ci-contracts"
+	"github.com/opentracing/opentracing-go"
+	opentracinglog "github.com/opentracing/opentracing-go/log"
+	"github.com/rs/zerolog/log"
+)
+
+// based on https://eli.thegreenplace.net/2020/pubsub-using-channels-in-go/
+
+type BuildTopicMessage struct {
+	Ctx   context.Context
+	Event contracts.Build
+}
+
+type BuildTopic struct {
+	name        string
+	mu          sync.RWMutex
+	subscribers map[string]chan BuildTopicMessage
+	closed      bool
+}
+
+func NewBuildTopic(name string) *BuildTopic {
+	return &BuildTopic{
+		name:        name,
+		subscribers: make(map[string]chan BuildTopicMessage, 0),
+	}
+}
+
+func (t *BuildTopic) Subscribe(name string) <-chan BuildTopicMessage {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	log.Info().Msgf("Subscribing %v to BuildTopic %v", name, t.name)
+
+	subscriber := make(chan BuildTopicMessage, 1)
+
+	t.subscribers[name] = subscriber
+
+	return subscriber
+}
+
+func (t *BuildTopic) Publish(publisher string, message BuildTopicMessage) {
+
+	span, ctx := opentracing.StartSpanFromContext(message.Ctx, helpers.GetSpanName("topics.GitEventTopic", "Publish"))
+	message.Ctx = ctx
+	defer func() { helpers.FinishSpan(span) }()
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	span.LogFields(opentracinglog.String("event", "LockAcquired"))
+
+	if t.closed {
+		return
+	}
+
+	log.Debug().Msgf("Publishing message from %v to %v subscribers in BuildTopic %v", publisher, len(t.subscribers), t.name)
+
+	for subscriber, ch := range t.subscribers {
+		log.Debug().Msgf("Publishing message from %v  to subscriber %v in BuildTopic %v", publisher, subscriber, t.name)
+		go func(ch chan BuildTopicMessage) {
+			ch <- message
+		}(ch)
+	}
+}
+
+func (t *BuildTopic) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	log.Info().Msgf("Closing channels for %v subscribers in BuildTopic %v", len(t.subscribers), t.name)
+
+	if !t.closed {
+		t.closed = true
+		for subscriber, ch := range t.subscribers {
+			log.Debug().Msgf("Closing channel for subscriber %v in BuildTopic %v", subscriber, t.name)
+			close(ch)
+		}
+	}
+}

--- a/topics/gitEventTopic.go
+++ b/topics/gitEventTopic.go
@@ -1,0 +1,86 @@
+package topics
+
+import (
+	"context"
+	"sync"
+
+	"github.com/estafette/estafette-ci-api/helpers"
+	manifest "github.com/estafette/estafette-ci-manifest"
+	"github.com/opentracing/opentracing-go"
+	opentracinglog "github.com/opentracing/opentracing-go/log"
+	"github.com/rs/zerolog/log"
+)
+
+// based on https://eli.thegreenplace.net/2020/pubsub-using-channels-in-go/
+
+type GitEventTopicMessage struct {
+	Ctx   context.Context
+	Event manifest.EstafetteGitEvent
+}
+
+type GitEventTopic struct {
+	name        string
+	mu          sync.RWMutex
+	subscribers map[string]chan GitEventTopicMessage
+	closed      bool
+}
+
+func NewGitEventTopic(name string) *GitEventTopic {
+	return &GitEventTopic{
+		name:        name,
+		subscribers: make(map[string]chan GitEventTopicMessage, 0),
+	}
+}
+
+func (t *GitEventTopic) Subscribe(name string) <-chan GitEventTopicMessage {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	log.Info().Msgf("Subscribing %v to GitEventTopic %v", name, t.name)
+
+	subscriber := make(chan GitEventTopicMessage, 1)
+
+	t.subscribers[name] = subscriber
+
+	return subscriber
+}
+
+func (t *GitEventTopic) Publish(publisher string, message GitEventTopicMessage) {
+
+	span, ctx := opentracing.StartSpanFromContext(message.Ctx, helpers.GetSpanName("topics.GitEventTopic", "Publish"))
+	message.Ctx = ctx
+	defer func() { helpers.FinishSpan(span) }()
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	span.LogFields(opentracinglog.String("event", "LockAcquired"))
+
+	if t.closed {
+		return
+	}
+
+	log.Debug().Msgf("Publishing message from %v to %v subscribers in GitEventTopic %v", publisher, len(t.subscribers), t.name)
+
+	for subscriber, ch := range t.subscribers {
+		log.Debug().Msgf("Publishing message from %v to subscriber %v in GitEventTopic %v", publisher, subscriber, t.name)
+		go func(ch chan GitEventTopicMessage) {
+			ch <- message
+		}(ch)
+	}
+}
+
+func (t *GitEventTopic) Close() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	log.Info().Msgf("Closing channels for %v subscribers in GitEventTopic %v", len(t.subscribers), t.name)
+
+	if !t.closed {
+		t.closed = true
+		for subscriber, ch := range t.subscribers {
+			log.Debug().Msgf("Closing channel for subscriber %v in GitEventTopic %v", subscriber, t.name)
+			close(ch)
+		}
+	}
+}


### PR DESCRIPTION
In order to decouple logic and let multiple actions happen for an event looking at using 'pub sub' pattern internally in the api.