### PR TITLE
inject container-registry-pull credentials 

### DIFF
--- a/clients/builderapi/client.go
+++ b/clients/builderapi/client.go
@@ -586,6 +586,7 @@ func (c *client) getBuilderConfig(ctx context.Context, ciBuilderParams CiBuilder
 
 	// add container-registry credentials to allow private registry images to be used in stages
 	credentials = contracts.AddCredentialsIfNotPresent(credentials, contracts.FilterCredentialsByPipelinesAllowList(contracts.GetCredentialsByType(c.encryptedConfig.Credentials, "container-registry"), ciBuilderParams.GetFullRepoPath()))
+	credentials = contracts.AddCredentialsIfNotPresent(credentials, contracts.FilterCredentialsByPipelinesAllowList(contracts.GetCredentialsByType(c.encryptedConfig.Credentials, "container-registry-pull"), ciBuilderParams.GetFullRepoPath()))
 
 	localBuilderConfig := contracts.BuilderConfig{
 		Credentials:     credentials,


### PR DESCRIPTION
regardless of images in the manifest, so estafette-ci-builder can use it to authenticate towards docker hub to avoid rate limiting