### PR TITLE
Add build control feature

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -10,7 +10,7 @@ labels:
 version:
   semver:
     major: 1
-    minor: 0
+    minor: 1
 
 triggers:
 - name: migrator

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,7 @@ require (
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
-	golang.org/x/text v0.3.5 // indirect
+	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
 	golang.org/x/tools v0.1.2 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -673,8 +673,9 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/main.go
+++ b/main.go
@@ -684,6 +684,7 @@ func configureGinGonic(config *api.APIConfig, bitbucketHandler bitbucket.Handler
 		jwtMiddlewareRoutes.GET("/api/config", estafetteHandler.GetConfig)
 		jwtMiddlewareRoutes.GET("/api/config/credentials", estafetteHandler.GetConfigCredentials)
 		jwtMiddlewareRoutes.GET("/api/config/trustedimages", estafetteHandler.GetConfigTrustedImages)
+		jwtMiddlewareRoutes.GET("/api/config/buildControl", estafetteHandler.GetConfigBuildControl)
 		jwtMiddlewareRoutes.GET("/api/pipelines", estafetteHandler.GetPipelines)
 		jwtMiddlewareRoutes.GET("/api/pipelines/:source/:owner/:repo", estafetteHandler.GetPipeline)
 		jwtMiddlewareRoutes.GET("/api/pipelines/:source/:owner/:repo/recentbuilds", estafetteHandler.GetPipelineRecentBuilds)

--- a/pkg/api/build_control.go
+++ b/pkg/api/build_control.go
@@ -1,0 +1,32 @@
+package api
+
+type List []string
+
+type BuildControl struct {
+	Bitbucket BitbucketBuildControl `yaml:"bitbucket,omitempty"`
+	Github    GithubBuildControl    `yaml:"github,omitempty"`
+}
+
+type BitbucketBuildControl struct {
+	Allowed BitbucketProjectsRepos `yaml:"allowed,omitempty"`
+	Blocked BitbucketProjectsRepos `yaml:"blocked,omitempty"`
+}
+
+type BitbucketProjectsRepos struct {
+	Projects List `yaml:"projects,omitempty"`
+	Repos    List `yaml:"repos,omitempty"`
+}
+
+type GithubBuildControl struct {
+	Allowed List `yaml:"allowed,omitempty"`
+	Blocked List `yaml:"blocked,omitempty"`
+}
+
+func (l List) Contains(toCheck string) bool {
+	for _, existing := range l {
+		if existing == toCheck {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -41,9 +41,13 @@ type APIConfig struct {
 	Credentials               []*contracts.CredentialConfig          `yaml:"credentials,omitempty" json:"credentials,omitempty"`
 	ClearDefaultTrustedImages bool                                   `yaml:"clearDefaultTrustedImages,omitempty"`
 	TrustedImages             []*contracts.TrustedImageConfig        `yaml:"trustedImages,omitempty" json:"trustedImages,omitempty"`
+	BuildControl              *BuildControl                          `yaml:"buildControl,omitempty"`
 }
 
 func (c *APIConfig) SetDefaults() {
+	if c.BuildControl == nil {
+		c.BuildControl = &BuildControl{}
+	}
 	if c.Integrations == nil {
 		c.Integrations = &APIConfigIntegrations{}
 	}

--- a/pkg/api/configs/test-config.yaml
+++ b/pkg/api/configs/test-config.yaml
@@ -282,3 +282,23 @@ catalog:
   filters:
   - type
   - team
+
+buildControl:
+  bitbucket:
+    allowed:
+      projects:
+        - project1
+        - project2
+      repos:
+        - repo1
+    blocked:
+      projects:
+        - project3
+        - project4
+      repos:
+        - repo2
+  github:
+    allowed:
+      - repo3
+    blocked:
+      - repo4

--- a/pkg/clients/bitbucketapi/domain.go
+++ b/pkg/clients/bitbucketapi/domain.go
@@ -147,6 +147,7 @@ type Repository struct {
 	Scm       string          `json:"scm"`
 	Links     RepositoryLinks `json:"links"`
 	Workspace *Workspace      `json:"workspace"`
+	Project   *Project        `json:"project"`
 }
 
 type Workspace struct {
@@ -158,6 +159,13 @@ type Workspace struct {
 // RepositoryLinks represents a collections of links for a Bitbucket repository
 type RepositoryLinks struct {
 	HTML Link `json:"html"`
+}
+
+type Project struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+	UUID string `json:"uuid"`
+	Key  string `json:"key"`
 }
 
 // Link represents a single link for Bitbucket

--- a/pkg/services/bitbucket/build_control.go
+++ b/pkg/services/bitbucket/build_control.go
@@ -12,6 +12,18 @@ func (s *service) isBuildBlocked(pushEvent bitbucketapi.RepositoryPushEvent) boo
 	project := pushEvent.Repository.Project
 	repoName := pushEvent.GetRepoName()
 
+	// blocked projects
+	blockedProjects := s.config.BuildControl.Bitbucket.Blocked.Projects
+	if blockedProjects.Contains(project.Key) ||
+		blockedProjects.Contains(project.Name) {
+		return true
+	}
+	// blocked repos
+	blockedRepos := s.config.BuildControl.Bitbucket.Blocked.Repos
+	if blockedRepos.Contains(repoName) {
+		return true
+	}
+
 	// allowed projects
 	allowedProjects := s.config.BuildControl.Bitbucket.Allowed.Projects
 	if allowedProjects.Contains(project.Key) ||
@@ -23,18 +35,7 @@ func (s *service) isBuildBlocked(pushEvent bitbucketapi.RepositoryPushEvent) boo
 	if allowedRepos.Contains(repoName) {
 		return false
 	}
-	// if allowed projects/repos are provided block other repos
-	if len(allowedProjects)+len(allowedRepos) > 0 {
-		return true
-	}
 
-	// blocked projects
-	blockedProjects := s.config.BuildControl.Bitbucket.Blocked.Projects
-	if blockedProjects.Contains(project.Key) ||
-		blockedProjects.Contains(project.Name) {
-		return true
-	}
-	// blocked repos
-	blockedRepos := s.config.BuildControl.Bitbucket.Blocked.Repos
-	return blockedRepos.Contains(repoName)
+	// block everything else if allowed projects/repos are provided
+	return len(allowedProjects)+len(allowedRepos) > 0
 }

--- a/pkg/services/bitbucket/build_control.go
+++ b/pkg/services/bitbucket/build_control.go
@@ -1,0 +1,40 @@
+package bitbucket
+
+import (
+	"github.com/estafette/estafette-ci-api/pkg/clients/bitbucketapi"
+)
+
+// isBuildBlocked check if repository is blocked from builds
+func (s *service) isBuildBlocked(pushEvent bitbucketapi.RepositoryPushEvent) bool {
+	if pushEvent.Repository.FullName == "" || pushEvent.Repository.Project == nil {
+		return false
+	}
+	project := pushEvent.Repository.Project
+	repoName := pushEvent.GetRepoName()
+
+	// allowed projects
+	allowedProjects := s.config.BuildControl.Bitbucket.Allowed.Projects
+	if allowedProjects.Contains(project.Key) ||
+		allowedProjects.Contains(project.Name) {
+		return false
+	}
+	// allowed repos
+	allowedRepos := s.config.BuildControl.Bitbucket.Allowed.Repos
+	if allowedRepos.Contains(repoName) {
+		return false
+	}
+	// if allowed projects/repos are provided block other repos
+	if len(allowedProjects)+len(allowedRepos) > 0 {
+		return true
+	}
+
+	// blocked projects
+	blockedProjects := s.config.BuildControl.Bitbucket.Blocked.Projects
+	if blockedProjects.Contains(project.Key) ||
+		blockedProjects.Contains(project.Name) {
+		return true
+	}
+	// blocked repos
+	blockedRepos := s.config.BuildControl.Bitbucket.Blocked.Repos
+	return blockedRepos.Contains(repoName)
+}

--- a/pkg/services/bitbucket/build_control_test.go
+++ b/pkg/services/bitbucket/build_control_test.go
@@ -1,0 +1,100 @@
+package bitbucket
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/estafette/estafette-ci-api/pkg/api"
+	"github.com/estafette/estafette-ci-api/pkg/clients/bitbucketapi"
+)
+
+func Test_isBuildBlocked(t *testing.T) {
+	pushEvent1 := bitbucketapi.RepositoryPushEvent{
+		Repository: bitbucketapi.Repository{
+			FullName: "/test-repo-1",
+			Project: &bitbucketapi.Project{
+				Name: "project-1",
+				Key:  "p1",
+			},
+		},
+	}
+	pushEvent2 := bitbucketapi.RepositoryPushEvent{
+		Repository: bitbucketapi.Repository{
+			FullName: "/test-repo-2",
+			Project: &bitbucketapi.Project{
+				Name: "project-2",
+				Key:  "p2",
+			},
+		},
+	}
+	genService := func(b *api.BuildControl) *service {
+		return &service{
+			config: &api.APIConfig{
+				BuildControl: b,
+			},
+		}
+	}
+	t.Run("NoAllowedOrBlocked", func(t *testing.T) {
+		var s = genService(&api.BuildControl{})
+		assertT := assert.New(t)
+		assertT.False(s.isBuildBlocked(pushEvent1))
+		assertT.False(s.isBuildBlocked(pushEvent2))
+	})
+	t.Run("AllowedProject", func(t *testing.T) {
+		var s = genService(&api.BuildControl{
+			Bitbucket: api.BitbucketBuildControl{
+				Allowed: api.BitbucketProjectsRepos{
+					Projects: api.List{
+						"p1",
+					},
+				},
+			},
+		})
+		assertT := assert.New(t)
+		assertT.False(s.isBuildBlocked(pushEvent1))
+		assertT.True(s.isBuildBlocked(pushEvent2))
+	})
+	t.Run("BlockedProject", func(t *testing.T) {
+		var s = genService(&api.BuildControl{
+			Bitbucket: api.BitbucketBuildControl{
+				Blocked: api.BitbucketProjectsRepos{
+					Projects: api.List{
+						"p1",
+					},
+				},
+			},
+		})
+		assertT := assert.New(t)
+		assertT.True(s.isBuildBlocked(pushEvent1))
+		assertT.False(s.isBuildBlocked(pushEvent2))
+	})
+	t.Run("AllowedRepo", func(t *testing.T) {
+		var s = genService(&api.BuildControl{
+			Bitbucket: api.BitbucketBuildControl{
+				Allowed: api.BitbucketProjectsRepos{
+					Repos: api.List{
+						"test-repo-1",
+					},
+				},
+			},
+		})
+		assertT := assert.New(t)
+		assertT.False(s.isBuildBlocked(pushEvent1))
+		assertT.True(s.isBuildBlocked(pushEvent2))
+	})
+	t.Run("BlockedRepo", func(t *testing.T) {
+		var s = genService(&api.BuildControl{
+			Bitbucket: api.BitbucketBuildControl{
+				Blocked: api.BitbucketProjectsRepos{
+					Repos: api.List{
+						"test-repo-1",
+					},
+				},
+			},
+		})
+		assertT := assert.New(t)
+		assertT.True(s.isBuildBlocked(pushEvent1))
+		assertT.False(s.isBuildBlocked(pushEvent2))
+	})
+}

--- a/pkg/services/bitbucket/build_control_test.go
+++ b/pkg/services/bitbucket/build_control_test.go
@@ -10,24 +10,20 @@ import (
 )
 
 func Test_isBuildBlocked(t *testing.T) {
-	pushEvent1 := bitbucketapi.RepositoryPushEvent{
-		Repository: bitbucketapi.Repository{
-			FullName: "/test-repo-1",
-			Project: &bitbucketapi.Project{
-				Name: "project-1",
-				Key:  "p1",
+	genEvent := func(fullName, projectName, projectKey string) bitbucketapi.RepositoryPushEvent {
+		return bitbucketapi.RepositoryPushEvent{
+			Repository: bitbucketapi.Repository{
+				FullName: fullName,
+				Project: &bitbucketapi.Project{
+					Name: projectName,
+					Key:  projectKey,
+				},
 			},
-		},
+		}
 	}
-	pushEvent2 := bitbucketapi.RepositoryPushEvent{
-		Repository: bitbucketapi.Repository{
-			FullName: "/test-repo-2",
-			Project: &bitbucketapi.Project{
-				Name: "project-2",
-				Key:  "p2",
-			},
-		},
-	}
+	pushEvent1 := genEvent("/test-repo-1", "project-1", "p1")
+	pushEvent2 := genEvent("/test-repo-2", "project-2", "p2")
+	pushEvent3 := genEvent("/test-repo-3", "project-3", "p3")
 	genService := func(b *api.BuildControl) *service {
 		return &service{
 			config: &api.APIConfig{
@@ -40,6 +36,7 @@ func Test_isBuildBlocked(t *testing.T) {
 		assertT := assert.New(t)
 		assertT.False(s.isBuildBlocked(pushEvent1))
 		assertT.False(s.isBuildBlocked(pushEvent2))
+		assertT.False(s.isBuildBlocked(pushEvent3))
 	})
 	t.Run("AllowedProject", func(t *testing.T) {
 		var s = genService(&api.BuildControl{
@@ -54,6 +51,7 @@ func Test_isBuildBlocked(t *testing.T) {
 		assertT := assert.New(t)
 		assertT.False(s.isBuildBlocked(pushEvent1))
 		assertT.True(s.isBuildBlocked(pushEvent2))
+		assertT.True(s.isBuildBlocked(pushEvent3))
 	})
 	t.Run("BlockedProject", func(t *testing.T) {
 		var s = genService(&api.BuildControl{
@@ -68,6 +66,7 @@ func Test_isBuildBlocked(t *testing.T) {
 		assertT := assert.New(t)
 		assertT.True(s.isBuildBlocked(pushEvent1))
 		assertT.False(s.isBuildBlocked(pushEvent2))
+		assertT.False(s.isBuildBlocked(pushEvent3))
 	})
 	t.Run("AllowedRepo", func(t *testing.T) {
 		var s = genService(&api.BuildControl{
@@ -82,6 +81,7 @@ func Test_isBuildBlocked(t *testing.T) {
 		assertT := assert.New(t)
 		assertT.False(s.isBuildBlocked(pushEvent1))
 		assertT.True(s.isBuildBlocked(pushEvent2))
+		assertT.True(s.isBuildBlocked(pushEvent3))
 	})
 	t.Run("BlockedRepo", func(t *testing.T) {
 		var s = genService(&api.BuildControl{
@@ -96,5 +96,26 @@ func Test_isBuildBlocked(t *testing.T) {
 		assertT := assert.New(t)
 		assertT.True(s.isBuildBlocked(pushEvent1))
 		assertT.False(s.isBuildBlocked(pushEvent2))
+		assertT.False(s.isBuildBlocked(pushEvent3))
+	})
+	t.Run("BlockedRepoAndAllowedProject", func(t *testing.T) {
+		var s = genService(&api.BuildControl{
+			Bitbucket: api.BitbucketBuildControl{
+				Allowed: api.BitbucketProjectsRepos{
+					Projects: api.List{
+						"pr1",
+					},
+				},
+				Blocked: api.BitbucketProjectsRepos{
+					Repos: api.List{
+						"test-repo-1",
+					},
+				},
+			},
+		})
+		assertT := assert.New(t)
+		assertT.True(s.isBuildBlocked(pushEvent1))
+		assertT.True(s.isBuildBlocked(pushEvent2))
+		assertT.True(s.isBuildBlocked(pushEvent3))
 	})
 }

--- a/pkg/services/bitbucket/service_test.go
+++ b/pkg/services/bitbucket/service_test.go
@@ -6,14 +6,15 @@ import (
 	"sync"
 	"testing"
 
+	manifest "github.com/estafette/estafette-ci-manifest"
+	gomock "github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/estafette/estafette-ci-api/pkg/api"
 	"github.com/estafette/estafette-ci-api/pkg/clients/bitbucketapi"
 	"github.com/estafette/estafette-ci-api/pkg/clients/pubsubapi"
 	"github.com/estafette/estafette-ci-api/pkg/services/estafette"
 	"github.com/estafette/estafette-ci-api/pkg/services/queue"
-	manifest "github.com/estafette/estafette-ci-manifest"
-	gomock "github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateJobForBitbucketPush(t *testing.T) {
@@ -208,6 +209,7 @@ func TestCreateJobForBitbucketPush(t *testing.T) {
 			Integrations: &api.APIConfigIntegrations{
 				Bitbucket: &api.BitbucketConfig{},
 			},
+			BuildControl: &api.BuildControl{},
 		}
 		bitbucketapiClient := bitbucketapi.NewMockClient(ctrl)
 		pubsubapiClient := pubsubapi.NewMockClient(ctrl)

--- a/pkg/services/estafette/transport.go
+++ b/pkg/services/estafette/transport.go
@@ -2599,6 +2599,18 @@ func (h *Handler) GetConfigTrustedImages(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"config": configString})
 }
 
+func (h *Handler) GetConfigBuildControl(c *gin.Context) {
+
+	configBytes, err := yaml.Marshal(h.config.BuildControl)
+	if err != nil {
+		log.Error().Err(err).Msgf("Failed marshalling buildControl")
+		c.JSON(http.StatusInternalServerError, gin.H{"code": http.StatusText(http.StatusInternalServerError)})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"config": string(configBytes)})
+}
+
 func (h *Handler) GetManifestTemplates(c *gin.Context) {
 
 	templateFiles, err := ioutil.ReadDir(h.templatesPath)


### PR DESCRIPTION
Added buildControl configuration that can block repositories from
building on estafette instance

Configuration has allowed/ blocked list, allowed list only builds
repositories mentioned under allowed projects/ repos. Blocked list will
block any repositories under listed projects/ repos

**Blocked list are processed first then allowed list, when allowed list is
provided repos outside of allowed projects/ repos are not build**

For Bitbucket allowed/ blocked list can be configured for both projects/
repos. For Github only repos can be configured