### PR TITLE
batch the migration builds query execution

### DIFF
--- a/pkg/clients/database/client.go
+++ b/pkg/clients/database/client.go
@@ -2933,11 +2933,9 @@ func (c *client) GetBuildsCount(ctx context.Context, filters map[api.FilterType]
 			From("builds a")
 
 	// dynamically set where clauses for filtering
-	if len(filters) > 0 {
-		query, err = whereClauseGeneratorForBuildFilters(query, filters)
-		if err != nil {
-			return
-		}
+	query, err = whereClauseGeneratorForBuildFilters(query, filters)
+	if err != nil {
+		return
 	}
 
 	// execute query

--- a/pkg/clients/database/client.go
+++ b/pkg/clients/database/client.go
@@ -2933,9 +2933,11 @@ func (c *client) GetBuildsCount(ctx context.Context, filters map[api.FilterType]
 			From("builds a")
 
 	// dynamically set where clauses for filtering
-	query, err = whereClauseGeneratorForBuildFilters(query, filters)
-	if err != nil {
-		return
+	if len(filters) > 0 {
+		query, err = whereClauseGeneratorForBuildFilters(query, filters)
+		if err != nil {
+			return
+		}
 	}
 
 	// execute query

--- a/pkg/clients/database/queries/get_builds_to_migrate_count.sql
+++ b/pkg/clients/database/queries/get_builds_to_migrate_count.sql
@@ -1,0 +1,8 @@
+SELECT
+    COUNT(id)
+FROM
+    builds
+WHERE
+    repo_source = @fromSource AND
+    repo_owner = @fromOwner AND
+    repo_name = @fromName

--- a/pkg/clients/database/queries/queries.go
+++ b/pkg/clients/database/queries/queries.go
@@ -21,6 +21,8 @@ var (
 	checkExistingMigration string
 	//go:embed get_all_migrations.sql
 	getAllMigrations string
+	//go:embed get_builds_to_migrate_count.sql
+	getBuildsToMigrateCount string
 	//go:embed get_migrated_build.sql
 	getMigratedBuild string
 	//go:embed get_migrated_build_logs.sql
@@ -114,6 +116,15 @@ func CheckExistingMigration(namedArg ...sql.NamedArg) (string, []interface{}) {
 
 func GetAllMigrations(namedArg ...sql.NamedArg) (string, []interface{}) {
 	return Prepare(getAllMigrations, namedArg)
+}
+
+// GetBuildsToMigrateCount prepares a query for execution by replacing named parameters with positional parameters.
+// Required NamedArg
+//   - fromName
+//   - fromOwner
+//   - fromSource
+func GetBuildsToMigrateCount(namedArg ...sql.NamedArg) (string, []interface{}) {
+	return Prepare(getBuildsToMigrateCount, namedArg)
 }
 
 // GetMigratedBuild prepares a query for execution by replacing named parameters with positional parameters.


### PR DESCRIPTION
- Adjusted migration builds logic to do batches in order to reduce the command execution size.
- Set the batch size hardcodes, I didn't want to do bigger changes for this sake.