### PR TITLE
feat: expose api for getting pipeline build by build/release version

### DIFF
--- a/.estafette.yaml
+++ b/.estafette.yaml
@@ -11,7 +11,7 @@ version:
   semver:
     major: 1
     minor: 5
-    patch: 6
+    patch: 7
 
 triggers:
 - name: migrator

--- a/main.go
+++ b/main.go
@@ -3,9 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/estafette/estafette-ci-api/pkg/migrationpb"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"io"
 	"net/http"
 	"os"
@@ -13,6 +10,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/estafette/estafette-ci-api/pkg/migrationpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	stdbigquery "cloud.google.com/go/bigquery"
 	stdpubsub "cloud.google.com/go/pubsub"
@@ -745,6 +746,7 @@ func configureGinGonic(config *api.APIConfig, bitbucketHandler bitbucket.Handler
 		jwtMiddlewareRoutes.GET("/api/pipelines/:source/:owner/:repo/recentbuilds", estafetteHandler.GetPipelineRecentBuilds)
 		jwtMiddlewareRoutes.GET("/api/pipelines/:source/:owner/:repo/buildbranches", estafetteHandler.GetPipelineBuildBranches)
 		jwtMiddlewareRoutes.GET("/api/pipelines/:source/:owner/:repo/builds", estafetteHandler.GetPipelineBuilds)
+		jwtMiddlewareRoutes.GET("/api/pipelines/:source/:owner/:repo/builds/version/:version", estafetteHandler.GetPipelineBuildByVersion)
 		jwtMiddlewareRoutes.GET("/api/pipelines/:source/:owner/:repo/builds/:revisionOrId", estafetteHandler.GetPipelineBuild)
 		jwtMiddlewareRoutes.GET("/api/pipelines/:source/:owner/:repo/builds/:revisionOrId/warnings", estafetteHandler.GetPipelineBuildWarnings)
 		jwtMiddlewareRoutes.GET("/api/pipelines/:source/:owner/:repo/builds/:revisionOrId/alllogs", estafetteHandler.GetPipelineBuildLogsPerPage)

--- a/pkg/services/estafette/transport.go
+++ b/pkg/services/estafette/transport.go
@@ -654,7 +654,7 @@ func (h *Handler) GetPipelineBuildLogsByID(c *gin.Context) {
 		build, err = h.databaseClient.GetPipelineBuildByID(c.Request.Context(), source, owner, repo, revisionOrID, false)
 		if err != nil {
 			log.Error().Err(err).
-				Msgf("Failed retrieving build for %v/%v/%v/builds/%v from db", source, owner, repo, revisionOrID)
+				Msgf("Failed retrieving build for %v/%v/%v/builds/%v from db", source, owner, repo, id)
 		}
 	}
 


### PR DESCRIPTION
## Context

Now the build supports revision or ID, but I don't want to support the version in the path directly despite it being unique, for the following reasons:

- Heavy judge the `/api/pipelines/:source/:owner/:repo/builds/:build` `:build` is a revision or ID or version
- Version is unique in theory but it depends on usage

So what I want is to get the ID via GetPipelineBuildByVersion and then do a redirect

## Related
- https://travix.atlassian.net/browse/TL-1487
- https://github.com/estafette/estafette-ci/issues/105